### PR TITLE
コードを表示、隠すボタンの実装等

### DIFF
--- a/Blockly/package-lock.json
+++ b/Blockly/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "blockly": "^11.0.0"
+        "blockly": "^11.0.0",
+        "dompurify": "^3.1.6"
       },
       "devDependencies": {
         "css-loader": "^6.7.1",
@@ -1323,6 +1324,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",

--- a/Blockly/package.json
+++ b/Blockly/package.json
@@ -24,6 +24,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "blockly": "^11.0.0"
+    "blockly": "^11.0.0",
+    "dompurify": "^3.1.6"
   }
 }

--- a/Blockly/src/blocks/html.js
+++ b/Blockly/src/blocks/html.js
@@ -1,0 +1,135 @@
+import * as Blockly from 'blockly';
+
+export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
+    'type': 'html_html-head-body',
+    'message0': '<html> %1 <head> %2 %3 </head> %4 <body> %5 %6 </body> %7 </html>',
+    'args0': [
+        {
+            'type': 'input_dummy'
+        },
+        {
+            'type': 'input_dummy'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'HEAD'
+        },
+        {
+            'type': 'input_dummy'
+        },
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'BODY'
+        },
+        {
+            'type': 'input_dummy'
+        },
+    ],
+},
+{
+    'type': 'html_comment',
+    'message0': '<!-- %1 --->',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'CONTENT',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_title',
+    'message0': '<title> %1 %2 </title>',
+    'args0': [
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT'
+        }
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_div',
+    'message0': '<div> %1 %2 </div>',
+    'args0': [
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT'
+        }
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_script',
+    'message0': '<script> %1 %2 </script>',
+    'args0': [
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT'
+        }
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_id',
+    'message0': 'id = "%1" %2',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'FIELD',
+        },
+        {
+            'type': 'input_value',
+            'name': 'VALUE'
+        }
+    ],
+    'output': null,
+},
+{
+    'type': 'html_color',
+    'message0': 'color = %1 %2',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'FIELD',
+            'text': '#000000'
+        },
+        {
+            'type': 'input_value',
+            'name': 'VALUE'
+        }
+    ],
+    'output': null,
+},
+{
+    'type': 'html_text',
+    'message0': '"%1"',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'CONTENT',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+}]);

--- a/Blockly/src/blocks/html.js
+++ b/Blockly/src/blocks/html.js
@@ -1,5 +1,6 @@
 import * as Blockly from 'blockly';
 
+// ブロックの見た目などを定義
 export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
     'type': 'html_html-head-body',
     'message0': '<html> %1 <head> %2 %3 </head> %4 <body> %5 %6 </body> %7 </html>',
@@ -44,7 +45,19 @@ export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
 },
 {
     'type': 'html_title',
-    'message0': '<title> %1 %2 </title>',
+    'message0': '<title> %1 </title>',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'CONTENT',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_div',
+    'message0': '<div> %1 %2 </div>',
     'args0': [
         {
             'type': 'input_value',
@@ -59,8 +72,8 @@ export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
     'nextStatement': null,
 },
 {
-    'type': 'html_div',
-    'message0': '<div> %1 %2 </div>',
+    'type': 'html_button',
+    'message0': '<button> %1 %2 </button>',
     'args0': [
         {
             'type': 'input_value',
@@ -132,4 +145,67 @@ export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
     ],
     'previousStatement': null,
     'nextStatement': null,
-}]);
+},
+{
+    'type': 'js_getElementById',
+    'message0': 'id="%1"の要素を取得し変数"%2"に代入',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'ID',
+        },
+        {
+            'type': 'field_input',
+            'name': 'NAME',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'js_addEventListener',
+    'message0': 'もし id="%1" が %2 されたら %3 %4',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'ID',
+        },
+        {
+            'type': 'field_dropdown',
+            'name': 'EVENT',
+            'options': [
+                ['クリック', 'click'],
+                ['マウスオーバー', 'mouseover'],
+                ['マウスアウト', 'mouseout'],
+                ['フォーカス', 'focus'],
+                ['フォーカスアウト', 'blur'],
+                ['キーダウン', 'keydown'],
+                ['キーアップ', 'keyup'],
+                ['キープレス', 'keypress'],
+            ],
+        },
+        {
+            'type': 'input_dummy'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT',
+            'check': 'Javascript',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'js_alert',
+    'message0': 'alert("%1")',
+    'args0': [
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT',
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+]);

--- a/Blockly/src/blocks/html.js
+++ b/Blockly/src/blocks/html.js
@@ -72,6 +72,38 @@ export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
     'nextStatement': null,
 },
 {
+    'type': 'html_ul',
+    'message0': '<ul> %1 %2 </ul>',
+    'args0': [
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+        {
+            'type': 'input_statement',
+            'name': 'CONTENT'
+        }
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
+    'type': 'html_li',
+    'message0': '<li> %1 </li> %2',
+    'args0': [
+        {
+            'type': 'field_input',
+            'name': 'CONTENT'
+        },
+        {
+            'type': 'input_value',
+            'name': 'ATTRIBUTE'
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
+{
     'type': 'html_button',
     'message0': '<button> %1 %2 </button>',
     'args0': [

--- a/Blockly/src/generators/html.js
+++ b/Blockly/src/generators/html.js
@@ -51,6 +51,23 @@ htmlGenerator.forBlock['html_div'] = function(block, generator) {
     const indentedCode = generator.prefixLines(code, generator.INDENT);
     return indentedCode;
 };
+htmlGenerator.forBlock['html_ul'] = function(block, generator) {
+    const content = generator.statementToCode(block, 'CONTENT');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const startTag = attribute ? `<ul ${attribute}>` : `<ul>`;
+    const code = content ? `${startTag}\n${content}</ul>\n` : `${startTag}</ul>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+htmlGenerator.forBlock['html_li'] = function(block, generator) {
+    const content = block.getFieldValue('CONTENT');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const sanitizedContent = DOMPurify.sanitize(content);
+    const startTag = attribute ? `<li ${attribute}>` : `<li>`;
+    const code =  `${startTag}${sanitizedContent}</li>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
 
 htmlGenerator.forBlock['html_button'] = function(block, generator) {
     const content = generator.statementToCode(block, 'CONTENT');
@@ -80,7 +97,7 @@ htmlGenerator.forBlock['html_id'] = function(block, generator) {
 htmlGenerator.forBlock['html_color'] = function(block, generator) {
     const field = block.getFieldValue('FIELD');
     const value = generator.valueToCode(block, 'VALUE', Order.ATOMIC);
-    const code = value ? `color=${field} ${value}` : `color=${field}`;
+    const code = value ? `style= "color:${field}" ${value}` : `style="color:${field}"`;
     return [code, Order.ATOMIC];
 };
 

--- a/Blockly/src/generators/html.js
+++ b/Blockly/src/generators/html.js
@@ -1,4 +1,5 @@
 import * as Blockly from 'blockly';
+import DOMPurify from 'dompurify';
 
 export const htmlGenerator = new Blockly.Generator('HTML');
 
@@ -65,7 +66,8 @@ htmlGenerator.forBlock['html_color'] = function(block, generator) {
 
 htmlGenerator.forBlock['html_text'] = function(block, generator) {
     const content = block.getFieldValue('CONTENT');
-    const code = `${content}\n`;
+    const sanitizedContent = DOMPurify.sanitize(content);
+    const code = `${sanitizedContent}\n`;
     const indentedCode = generator.prefixLines(code, generator.INDENT);
     return indentedCode;
 };

--- a/Blockly/src/generators/html.js
+++ b/Blockly/src/generators/html.js
@@ -1,0 +1,71 @@
+import * as Blockly from 'blockly';
+
+export const htmlGenerator = new Blockly.Generator('HTML');
+
+const Order = {
+    ATOMIC: 0,
+};
+
+htmlGenerator.scrub_ = function(block, code, thisOnly) {
+    const nextBlock =
+        block.nextConnection && block.nextConnection.targetBlock();
+    if (nextBlock && !thisOnly) {
+      return code + htmlGenerator.blockToCode(nextBlock);
+    }
+    return code;
+};
+
+htmlGenerator.forBlock['html_html-head-body'] = function(block, generator) {
+    const headContent = generator.statementToCode(block, 'HEAD');
+    const bodyContent = generator.statementToCode(block, 'BODY');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const startBodyTag = attribute ? `<body ${attribute}>` : `<body>`;
+    const code = `<html>\n<head>\n${headContent}</head>\n${startBodyTag}\n${bodyContent}</body>\n</html>\n`;
+    return code;
+};
+
+htmlGenerator.forBlock['html_comment'] = function(block, generator) {
+    const content = block.getFieldValue('CONTENT');
+    const code = `<!-- ${content} --->\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['html_div'] = function(block, generator) {
+    const content = generator.statementToCode(block, 'CONTENT');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const startTag = attribute ? `<div ${attribute}>` : `<div>`;
+    const code = content ? `${startTag}\n${content}</div>\n` : `${startTag}</div>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['html_script'] = function(block, generator) {
+    const content = generator.statementToCode(block, 'CONTENT');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const startTag = attribute ? `<script ${attribute}>` : `<script>`;
+    const code = content ? `${startTag}\n${content}</script>\n` : `${startTag}</script>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['html_id'] = function(block, generator) {
+    const field = block.getFieldValue('FIELD');
+    const value = generator.valueToCode(block, 'VALUE', Order.ATOMIC);
+    const code = value ? `id="${field}" ${value}` : `id="${field}"`;
+    return [code, Order.ATOMIC]; // valueは配列で返す
+};
+
+htmlGenerator.forBlock['html_color'] = function(block, generator) {
+    const field = block.getFieldValue('FIELD');
+    const value = generator.valueToCode(block, 'VALUE', Order.ATOMIC);
+    const code = value ? `color=${field} ${value}` : `color=${field}`;
+    return [code, Order.ATOMIC];
+};
+
+htmlGenerator.forBlock['html_text'] = function(block, generator) {
+    const content = block.getFieldValue('CONTENT');
+    const code = `${content}\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};

--- a/Blockly/src/generators/html.js
+++ b/Blockly/src/generators/html.js
@@ -3,10 +3,13 @@ import DOMPurify from 'dompurify';
 
 export const htmlGenerator = new Blockly.Generator('HTML');
 
+// 演算子の優先順位を定義（現状は優先なし）
 const Order = {
     ATOMIC: 0,
 };
 
+// input_statement内のstatementブロックを再帰的に読み取る
+// statementブロックが複数個の場合はこれが必要
 htmlGenerator.scrub_ = function(block, code, thisOnly) {
     const nextBlock =
         block.nextConnection && block.nextConnection.targetBlock();
@@ -16,6 +19,7 @@ htmlGenerator.scrub_ = function(block, code, thisOnly) {
     return code;
 };
 
+// ブロックの生成するコードを定義
 htmlGenerator.forBlock['html_html-head-body'] = function(block, generator) {
     const headContent = generator.statementToCode(block, 'HEAD');
     const bodyContent = generator.statementToCode(block, 'BODY');
@@ -32,11 +36,27 @@ htmlGenerator.forBlock['html_comment'] = function(block, generator) {
     return indentedCode;
 };
 
+htmlGenerator.forBlock['html_title'] = function(block, generator) {
+    const content = block.getFieldValue('CONTENT');
+    const code = `<title>${content}</title>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
 htmlGenerator.forBlock['html_div'] = function(block, generator) {
     const content = generator.statementToCode(block, 'CONTENT');
     const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
     const startTag = attribute ? `<div ${attribute}>` : `<div>`;
     const code = content ? `${startTag}\n${content}</div>\n` : `${startTag}</div>\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['html_button'] = function(block, generator) {
+    const content = generator.statementToCode(block, 'CONTENT');
+    const attribute = generator.valueToCode(block, 'ATTRIBUTE', Order.ATOMIC);
+    const startTag = attribute ? `<button ${attribute}>` : `<button>`;
+    const code = content ? `${startTag}\n${content}</button>\n` : `${startTag}</button>\n`;
     const indentedCode = generator.prefixLines(code, generator.INDENT);
     return indentedCode;
 };
@@ -68,6 +88,33 @@ htmlGenerator.forBlock['html_text'] = function(block, generator) {
     const content = block.getFieldValue('CONTENT');
     const sanitizedContent = DOMPurify.sanitize(content);
     const code = `${sanitizedContent}\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['js_getElementById'] = function(block, generator) {
+    const id = block.getFieldValue('ID');
+    const name = block.getFieldValue('NAME');
+    const sanitizedId = DOMPurify.sanitize(id);
+    const sanitizedName = DOMPurify.sanitize(name);
+    const code = (sanitizedId && sanitizedName) ? `const ${sanitizedName} = document.getElementById("${sanitizedId}");\n` : "\n";
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['js_addEventListener'] = function(block, generator) {
+    const id = block.getFieldValue('ID');
+    const event = block.getFieldValue('EVENT');
+    const content = generator.statementToCode(block, 'CONTENT');
+    const sanitizedId = DOMPurify.sanitize(id);
+    const code = `${sanitizedId}.addEventListener("${event}", () => {\n${content}});\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};
+
+htmlGenerator.forBlock['js_alert'] = function(block, generator) {
+    const content = generator.statementToCode(block, 'CONTENT');
+    const code = `alert(${content.trimEnd()});\n`;
     const indentedCode = generator.prefixLines(code, generator.INDENT);
     return indentedCode;
 };

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -28,7 +28,7 @@ const ws = Blockly.inject(blocklyDiv, {toolbox});
 // generated code from the workspace, and evals the code.
 // In a real application, you probably shouldn't use `eval`.
 const runCode = () => {
-  const code = javascriptGenerator.workspaceToCode(ws);
+  const code = htmlGenerator.workspaceToCode(ws);
   codeDiv.innerText = code;
 
   outputDiv.innerHTML = code;

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -13,6 +13,7 @@ import {htmlGenerator} from './generators/html';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
 import './index.css';
+import DOMPurify from 'dompurify';
 
 // Register the blocks and generator with Blockly
 Blockly.common.defineBlocks(htmlBlocks);
@@ -22,7 +23,25 @@ Object.assign(javascriptGenerator.forBlock, forBlock);
 const codeDiv = document.getElementById('generatedCode').firstChild;
 const outputDiv = document.getElementById('output');
 const blocklyDiv = document.getElementById('blocklyDiv');
-const ws = Blockly.inject(blocklyDiv, {toolbox});
+const ws = Blockly.inject(blocklyDiv, {
+  // ワークスペースにおける見た目などの設定
+  toolbox, //使用するツールボックスを定義
+  grid: {
+    spacing: 20,    // グリッド線の間隔
+    length: 3,      // グリッド線の長さ
+    colour: '#ccc', // グリッド線の色
+    snap: true      // グリッドにスナップさせるかどうか
+  },
+  zoom: {
+    controls: true, // ズーム可能かどうか
+    wheel: false,   // マウスホイールでズーム可能かどうか
+    startScale: 1,  // 初期のズーム倍率
+    maxScale: 5,    // 最大ズーム倍率
+    minScale: 0.5,  // 最小ズーム倍率
+    // scaleSpeed: 1.2, // 1回毎のズーム倍率
+  },
+  sounds: true, // 音を鳴らすかどうか
+});
 
 // This function resets the code and output divs, shows the
 // generated code from the workspace, and evals the code.
@@ -34,6 +53,25 @@ const runCode = () => {
   outputDiv.innerHTML = code;
 
   // eval(code);
+
+  // 正規表現で <script> タグを取り出す
+  const scriptRegex = /<script>([\s\S]*?)<\/script>/;
+  const match = code.match(scriptRegex);
+
+  // スクリプト部分とそれ以外の部分を抽出
+  const scriptCode = match ? match[1] : '';
+  
+  // スクリプトを動的に評価
+  try {
+      eval(DOMPurify.sanitize(scriptCode));
+  } catch (e) {
+      console.error(e);
+  }
+
+  // スクリプトを動的に評価
+  // const script = document.createElement('script');
+  // script.textContent = scriptCode;
+  // document.body.appendChild(script);
 };
 
 // Load the initial state from storage and run the code.

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -6,14 +6,16 @@
 
 import * as Blockly from 'blockly';
 import {blocks} from './blocks/text';
+import {htmlBlocks} from './blocks/html';
 import {forBlock} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
+import {htmlGenerator} from './generators/html';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
 import './index.css';
 
 // Register the blocks and generator with Blockly
-Blockly.common.defineBlocks(blocks);
+Blockly.common.defineBlocks(htmlBlocks);
 Object.assign(javascriptGenerator.forBlock, forBlock);
 
 // Set up UI elements and inject Blockly
@@ -29,9 +31,9 @@ const runCode = () => {
   const code = javascriptGenerator.workspaceToCode(ws);
   codeDiv.innerText = code;
 
-  outputDiv.innerHTML = '';
+  outputDiv.innerHTML = code;
 
-  eval(code);
+  // eval(code);
 };
 
 // Load the initial state from storage and run the code.

--- a/Blockly/src/serialization.js
+++ b/Blockly/src/serialization.js
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 
-const storageKey = 'mainWorkspace';
+const storageKey = 'htmlGeneratorWorkspace';
 
 /**
  * Saves the state of the workspace to browser's local storage.

--- a/Blockly/src/serialization.js
+++ b/Blockly/src/serialization.js
@@ -6,6 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 
+// キャッシュの保存先を決定
 const storageKey = 'htmlGeneratorWorkspace';
 
 /**

--- a/Blockly/src/toolbox.js
+++ b/Blockly/src/toolbox.js
@@ -38,6 +38,14 @@ export const toolbox = {
         },
         {
           'kind': 'block',
+          'type': 'html_ul'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_li'
+        },
+        {
+          'kind': 'block',
           'type': 'html_button'
         },
         {

--- a/Blockly/src/toolbox.js
+++ b/Blockly/src/toolbox.js
@@ -13,8 +13,42 @@ listed here.
 */
 
 export const toolbox = {
-  kind: 'categoryToolbox',
-  contents: [
+  'kind': 'categoryToolbox',
+  'contents': [
+    {
+      'kind': 'CATEGORY',
+      'name': 'html elements',
+      'contents': [
+        {
+          'kind': 'block',
+          "type": "html_html-head-body"
+        },
+        {
+          'kind': 'block',
+          'type': 'html_comment'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_div'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_script'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_id'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_color'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_text'
+        },
+      ]
+    },
     {
       kind: 'category',
       name: 'Logic',
@@ -625,5 +659,5 @@ export const toolbox = {
       categorystyle: 'procedure_category',
       custom: 'PROCEDURE',
     },
-  ],
-};
+  ]
+}

--- a/Blockly/src/toolbox.js
+++ b/Blockly/src/toolbox.js
@@ -12,6 +12,7 @@ your toolbox from scratch, or carefully choosing whether you need each block
 listed here.
 */
 
+// ツールボックスの構成
 export const toolbox = {
   'kind': 'categoryToolbox',
   'contents': [
@@ -29,7 +30,15 @@ export const toolbox = {
         },
         {
           'kind': 'block',
+          'type': 'html_title'
+        },
+        {
+          'kind': 'block',
           'type': 'html_div'
+        },
+        {
+          'kind': 'block',
+          'type': 'html_button'
         },
         {
           'kind': 'block',
@@ -46,6 +55,24 @@ export const toolbox = {
         {
           'kind': 'block',
           'type': 'html_text'
+        },
+      ]
+    },
+    {
+      kind: 'category',
+      name: 'JavaScript',
+      contents: [
+        {
+          kind: 'block',
+          type: 'js_getElementById'
+        },
+        {
+          kind: 'block',
+          type: 'js_addEventListener'
+        },
+        {
+          kind: 'block',
+          type: 'js_alert'
         },
       ]
     },


### PR DESCRIPTION
コードを表示、隠すボタンを実装しました。

CSSで、要素を隠すclass と要素を大きく出す class を作りました。
index.jsでボタンの要素( id=button )、コードを表示する要素(id = generatedCode )のIDを取得してボタンをクリックする度に id = generated のコードの class を入れ替えるようにすることでこのボタンが実装できました。

他にBlockly で置いたブロックの出力 ( id = output ) にoverflow: auto をつけたり、上から id =output , button , generatedCode になるようにしたりしてます。
あと、CSSで height を 100% 以上にしてるところがあります。

初プルリクエストなので何かおかしくなったらこれのせいかもしれないです。よく分かんないので見てみてください。
