### PR TITLE
コードを表示、隠すボタンの実装(再)

### DIFF
--- a/Blockly/src/blocks/html.js
+++ b/Blockly/src/blocks/html.js
@@ -240,4 +240,17 @@ export const htmlBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([{
     'previousStatement': null,
     'nextStatement': null,
 },
+{
+    'type': 'js_string',
+    'message0': '"%1"',
+    'args0' : [
+        {
+            'type': 'field_input',
+            'name': 'CONTENT',
+            'text': '文字列'
+        },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+},
 ]);

--- a/Blockly/src/generators/html.js
+++ b/Blockly/src/generators/html.js
@@ -135,3 +135,10 @@ htmlGenerator.forBlock['js_alert'] = function(block, generator) {
     const indentedCode = generator.prefixLines(code, generator.INDENT);
     return indentedCode;
 };
+htmlGenerator.forBlock['js_string'] = function(block, generator) {
+    const content = block.getFieldValue('CONTENT');
+    const sanitizedContent = DOMPurify.sanitize(content);
+    const code = `"${sanitizedContent}"\n`;
+    const indentedCode = generator.prefixLines(code, generator.INDENT);
+    return indentedCode;
+};

--- a/Blockly/src/index.css
+++ b/Blockly/src/index.css
@@ -19,22 +19,58 @@ code {
   flex-basis: 100%;
   height: 100%;
   min-width: 600px;
+  order: 1;
 }
 
 #outputPane {
   display: flex;
   flex-direction: column;
   width: 400px;
+  height: 100%;
   flex: 0 0 400px;
   overflow: auto;
   margin: 1rem;
+  order: 2;
 }
 
 #generatedCode {
-  height: 50%;
   background-color: rgb(247, 240, 228);
+  order: 5;
 }
 
 #output {
-  height: 50%;
+  height: 70%;
+  order: 3;
+  overflow: auto  ;
+}
+
+#button {
+  position: relative;
+  height: 50px;
+  width: 150px;
+  order: 4;
+  margin: 0 auto
+}
+
+
+.split-view {
+  display: flex;
+}
+.split-view.vertical{
+  flex-direction: row;
+}
+.split-view.holizontal{
+  flex-direction: column;
+}
+
+
+.afterClicked {
+  position: relative;
+  height: 160%;
+  background-color: rgb(247,240,228);
+  order:  5;
+}
+
+.beforeClicked {
+  display: none;
 }

--- a/Blockly/src/index.css
+++ b/Blockly/src/index.css
@@ -74,3 +74,16 @@ code {
 .beforeClicked {
   display: none;
 }
+
+.hidden {
+  display:none;
+}
+
+#errorMessage {
+  display: block;
+  order: 6;
+  background-color: #FFA9A9;
+  padding: 20px;
+  color: #EFFDFF;
+  
+}

--- a/Blockly/src/index.html
+++ b/Blockly/src/index.html
@@ -11,6 +11,7 @@
           <pre id="generatedCode" class="beforeClicked"><code></code></pre>
           <div id="output"></div>
           <button id="button">コードを表示する</button>
+          <div id="errorMessage" //class="hidden"//>コラ～</div>
         </div>
         <div id="blocklyDiv"></div>
       </div>

--- a/Blockly/src/index.html
+++ b/Blockly/src/index.html
@@ -5,12 +5,15 @@
     <title>Blockly Sample App</title>
   </head>
   <body>
-    <div id="pageContainer">
-      <div id="outputPane">
-        <pre id="generatedCode"><code></code></pre>
-        <div id="output"></div>
+    <div class="split-view vertical">
+      <div id="pageContainer">
+        <div id="outputPane">
+          <pre id="generatedCode" class="beforeClicked"><code></code></pre>
+          <div id="output"></div>
+          <button id="button">コードを表示する</button>
+        </div>
+        <div id="blocklyDiv"></div>
       </div>
-      <div id="blocklyDiv"></div>
     </div>
   </body>
 </html>

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -99,6 +99,19 @@ ws.addChangeListener((e) => {
     return;
   }
   runCode();
+
+  function getCodeContent(){
+    const getCodeId = document.getElementById("generatedCode");
+    const pickCode = getCodeId.querySelector("code");
+    const getContentOfCode = pickCode ? pickCode.textContent : getCodeId.textContent;
+    return getContentOfCode
+  };
+  const outputId = document.getElementById("output");
+  const addDiv = document.createElement("div")
+  addDiv.textContent = getCodeContent();
+  outputId.appendChild(addDiv);
+
+
 });
 
 document.getElementById("button").onclick = () => {
@@ -112,3 +125,12 @@ document.getElementById("button").onclick = () => {
     getButtonID.textContent = "コードを表示する";
   }
 }
+
+/*
+const getButtonId = document.getElementById("button");
+if (not (getCodeContent() === "")) {
+  const getPageContainerId = doccument.getElementById("pageContainer");
+  const addDiv = document.createElement("div");
+  addDiv.textContent = getCodeContent();
+  getButtonId.appendChild(addDiv);
+*/

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -67,7 +67,7 @@ const runCode = () => {
   } catch (e) {
       console.error(e);
   }
-
+  
   // スクリプトを動的に評価
   // const script = document.createElement('script');
   // script.textContent = scriptCode;

--- a/Blockly/src/index.js
+++ b/Blockly/src/index.js
@@ -60,3 +60,15 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
+
+document.getElementById("button").onclick = () => {
+  const getCodeID = document.getElementById("generatedCode");
+  const getButtonID = document.getElementById("button");
+  getCodeID.classList.toggle("afterClicked");
+  getCodeID.classList.toggle("beforeClicked");
+  if (getButtonID.textContent === "コードを表示する"){
+    getButtonID.textContent = "コードを隠す";
+  } else {
+    getButtonID.textContent = "コードを表示する";
+  }
+}

--- a/Blockly/src/toolbox.js
+++ b/Blockly/src/toolbox.js
@@ -82,6 +82,10 @@ export const toolbox = {
           kind: 'block',
           type: 'js_alert'
         },
+        {
+          kind: 'block',
+          type: 'js_string'
+        }
       ]
     },
     {


### PR DESCRIPTION
ちゃんとできてんのかわからないので再び投げます。

~~~~~~~~~~~~~~~~~~~~~
コードを表示、隠すボタンを実装しました。

CSSで、要素を隠すclass と要素を大きく出す class を作りました。
index.jsでボタンの要素( id=button )、コードを表示する要素(id = generatedCode )のIDを取得してボタンをクリックする度に id = generated のコードの class を入れ替えるようにすることでこのボタンが実装できました。

他にBlockly で置いたブロックの出力 ( id = output ) にoverflow: auto をつけたり、上から id =output , button , generatedCode になるようにしたりしてます。
あと、CSSで height を 100% 以上にしてるところがあります。

初プルリクエストなので何かおかしくなったらこれのせいかもしれないです。よく分かんないので見てみてください。